### PR TITLE
Overhaul of spawn-blocking mechanics

### DIFF
--- a/ManageCreatureSpawns/Main.cs
+++ b/ManageCreatureSpawns/Main.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -22,24 +22,27 @@ namespace ManageCreatureSpawns {
 
       public static class Manager {
          public static bool TryKillCreature(Creature creature) {
-            if (creature != null && creature.enabled
-               && creature.gameObject != null)
+            if (creature != null
+			   && creature.enabled
+			   && creature.Friendliness.Value != 1
+			   && creature.version == 3
+			   && creature.gameObject != null)
             {
                var creatureConfiguration = settings.UnwantedCreaturesList.FirstOrDefault(c =>
                   c.Name.ToLowerInvariant() == creature.name.Replace("(Clone)", String.Empty).ToLowerInvariant());
                if (creatureConfiguration != null)
                {
-                  if (!creatureConfiguration.SpawnConfiguration.CanSpawn
-                     || rEngine.Next(0, 100) <= creatureConfiguration.SpawnConfiguration.SpawnChance)
+                  if (rEngine.Next(0, 100) >= creatureConfiguration.SpawnConfiguration.SpawnChance)
                   {
                      creature.tag = "Untagged";
+                     creature.version = 4;
                      creature.leashPosition = UnityEngine.Vector3.zero;
 
                      CreatureDeath cDeath = creature.gameObject.GetComponent<CreatureDeath>();
                      if (cDeath != null)
                      {
                         cDeath.eatable = null;
-                        cDeath.respawn = false;
+                        cDeath.respawn = creatureConfiguration.SpawnConfiguration.CanRespawn;
                         cDeath.removeCorpseAfterSeconds = 1.0f;
                      }
                      if (creature.liveMixin != null && creature.liveMixin.IsAlive())
@@ -58,6 +61,13 @@ namespace ManageCreatureSpawns {
                         creature.BroadcastMessage("OnKill");
                      }
                      return true;
+                  }
+				  else {
+                     creature.version = 4;
+                     CreatureDeath cDeath = creature.gameObject.GetComponent<CreatureDeath>();
+                     if (cDeath != null) {
+                        cDeath.respawn = creatureConfiguration.SpawnConfiguration.CanRespawn;
+                     }
                   }
                }
             }

--- a/ManageCreatureSpawns/Settings.xml
+++ b/ManageCreatureSpawns/Settings.xml
@@ -6,8 +6,8 @@
          <Creature>
             <Name>Creature's name goes here</Name>
             <SpawnConfiguration>
-               <CanSpawn>'true' or 'false'</CanSpawn>
                <SpawnChanceOutOf100>'0' to '100'</SpawnChanceOutOf100>
+               <CanRespawn>'true' or 'false'</CanRespawn>
             </SpawnConfiguration>
          </Creature>
       -->
@@ -15,19 +15,18 @@
     <Creature>
       <Name>Biter_02</Name>
       <SpawnConfiguration>
-        <!-- Enable/Disable the creature's spawn: `true` or `false` -->
-        <CanSpawn>true</CanSpawn>
-        <!-- Only used when CanSpawn is `true`. Range is from 0 to 100. -->
+        <!-- Range is from 0 to 100. 0 prevents the creature from ever spawning, 100 does not affect the creature's spawning.  -->
         <SpawnChanceOutOf100>50</SpawnChanceOutOf100>
+        <!-- Enable/Disable the creature's respawn: `true` or `false` -->
+        <CanRespawn>true</CanRespawn>
       </SpawnConfiguration>
     </Creature>
     <Creature>
       <!-- Works because <Name> is NOT case sensitive -->
       <Name>PEEper</Name>
       <SpawnConfiguration>
-        <CanSpawn>false</CanSpawn>
-        <!-- SpawnChanceOutOf100 is now ignored because CanSpawn is set to `false`. -->
         <SpawnChanceOutOf100>100</SpawnChanceOutOf100>
+        <CanRespawn>false</CanRespawn>
       </SpawnConfiguration>
     </Creature>
   </UnwantedCreatures>

--- a/ManageCreatureSpawns/SettingsManager.cs
+++ b/ManageCreatureSpawns/SettingsManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Xml.Serialization;
 
@@ -7,12 +7,12 @@ namespace ManageCreatureSpawns {
       [Serializable()]
       [XmlRoot("SpawnConfiguration")]
       public class SpawnConfiguration {
-         [XmlElement("CanSpawn")]
-         public bool CanSpawn { get; set; } = true;
-
          [XmlElement("SpawnChanceOutOf100")]
          public int SpawnChance { get; set; } = 100;
-      }
+
+         [XmlElement("CanRespawn")]
+         public bool CanRespawn { get; set; } = true;
+		}
 
       [Serializable()]
       [XmlRoot("Creature")]
@@ -29,11 +29,11 @@ namespace ManageCreatureSpawns {
                "Creature {{\r\n" +
                "  Name: {0}\r\n" +
                "  SpawnConfiguration {{\r\n" +
-               "     CanSpawn:    {1}\r\n" +
-               "     SpawnChance: {2}\r\n" +
-               "  }}\r\n" +
+               "     SpawnChance: {1}\r\n" +
+			   "     CanRespawn: {2}\r\n" +
+			   "  }}\r\n" +
                "}}",
-               Name, SpawnConfiguration.CanSpawn, SpawnConfiguration.SpawnChance);
+               Name, SpawnConfiguration.SpawnChance, SpawnConfiguration.CanRespawn);
          }
       }
 

--- a/ManageCreatureSpawns/mod.json
+++ b/ManageCreatureSpawns/mod.json
@@ -2,7 +2,7 @@
   "Id": "ManageCreatureSpawns",
   "DisplayName": "Manage Creature Spawns",
   "Author": "berkay(2578)",
-  "Version": "1.2.0.0",
+  "Version": "1.3.0.0",
   "Requires": [
     "0Harmony.dll"
   ],


### PR DESCRIPTION
I tested out some changes that would correct the behavior of partially-blocked creatures (e.g., 50% chance to spawn) to make it work more how I believe you intended. Due to some odd behavior from the game engine, the spawn-blocking code was being repeatedly called, which was causing any partially-blocked creatures to be completely removed from the game due to being checked over and over until they failed the spawn-blocking check.